### PR TITLE
[S0.1.1] Initialize repository via codex

### DIFF
--- a/.github/workflows/approval.yml
+++ b/.github/workflows/approval.yml
@@ -1,0 +1,10 @@
+name: Require Approval
+
+on:
+  pull_request:
+
+jobs:
+  wait-for-approval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/wait-for-approval@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npm audit --production
+      - uses: supabase/setup-cli@v1
+      - run: supabase migration up

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.env
+/dist
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Vibeflow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Vibeflow
+
+Bootstrap project for the Vibeflow platform.
+
+## Requirements
+- Node.js 20.x
+- TypeScript
+
+## Scripts
+- `npm test` – run Jest tests.
+- `npm run build` – compile TypeScript.
+
+## Continuous Integration
+GitHub Actions run tests and security checks on each push and pull request.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  passWithNoTests: true,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vibeflow",
+  "version": "0.1.0",
+  "description": "Vibeflow core",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.11.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add project bootstrap with README, license, and gitignore
- configure TypeScript, Jest scaffold, and package metadata
- set up CI workflows for tests, security, and manual approval

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `supabase migration up` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92bf53788326a0a76a3a3f98618e